### PR TITLE
safely map string boolean values

### DIFF
--- a/lib/mapper.js
+++ b/lib/mapper.js
@@ -16,6 +16,19 @@ const DepGraph = require('dependency-graph').DepGraph;
 const Query = require('./query');
 
 /**
+ * Parse a boolean from a string (ex. !!"false" === true, parseBooleanFromString("false") === false)
+ * @param str
+ * @returns {boolean}
+ */
+const parseBooleanFromString = str => {
+    try {
+        return !!JSON.parse(str);
+    } catch (e) {
+        return false;
+    }
+};
+
+/**
  * The Mapper provides generic methods to map document
  * objects to the underlying adapter database
  *
@@ -531,7 +544,12 @@ class Mapper {
 
                     } else if (field.type === 'boolean') {
 
-                        value = !!value;
+                        if (typeof value === 'string') {
+                            value = parseBooleanFromString(value);
+                        } else {
+                            value = !!value;
+                        }
+
                     }
 
                     const func = 'set' + field.property.charAt(0).toUpperCase() + field.property.substr(1, field.property.length);


### PR DESCRIPTION
Using !!value for boolean mapping doesn't work when value is "false".  !!"false" === true